### PR TITLE
Added Scale import for use in game config.

### DIFF
--- a/src/game/main.js
+++ b/src/game/main.js
@@ -3,7 +3,7 @@ import { Game as MainGame } from './scenes/Game';
 import { GameOver } from './scenes/GameOver';
 import { MainMenu } from './scenes/MainMenu';
 import { Preloader } from './scenes/Preloader';
-import { AUTO, Game } from 'phaser';
+import { AUTO, Game, Scale } from 'phaser';
 
 //  Find out more information about the Game Config at:
 //  https://docs.phaser.io/api-documentation/typedef/types-core#gameconfig
@@ -14,8 +14,8 @@ const config = {
     parent: 'game-container',
     backgroundColor: '#028af8',
     scale: {
-        mode: Phaser.Scale.FIT,
-        autoCenter: Phaser.Scale.CENTER_BOTH
+        mode: Scale.FIT,
+        autoCenter: Scale.CENTER_BOTH
     },
     scene: [
         Boot,


### PR DESCRIPTION
main.js still used Phaser.Scale instead of named imports. Added Scale and replaced usage.

`Uncaught ReferenceError: Phaser is not defined
    at main.js:17:15`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small import/reference fix in the Phaser game bootstrap that only affects scaling configuration and resolves a runtime `Phaser is not defined` error.
> 
> **Overview**
> Fixes the Phaser bootstrap to stop referencing the global `Phaser` object by importing `Scale` from `phaser` and using `Scale.FIT`/`Scale.CENTER_BOTH` in `src/game/main.js` game config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd4159a211df3c340e280bfeca4c6d8aaa780183. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->